### PR TITLE
Fix unused variable warning

### DIFF
--- a/Src/stm32f4xx_hal_pwr.c
+++ b/Src/stm32f4xx_hal_pwr.c
@@ -378,6 +378,9 @@ void HAL_PWR_DisableWakeUpPin(uint32_t WakeUpPinx)
   */
 void HAL_PWR_EnterSLEEPMode(uint32_t Regulator, uint8_t SLEEPEntry)
 {
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(Regulator);
+
   /* Check the parameters */
   assert_param(IS_PWR_REGULATOR(Regulator));
   assert_param(IS_PWR_SLEEP_ENTRY(SLEEPEntry));


### PR DESCRIPTION
Fixed unused variable compiler warning in stm32f4xx_hal_pwr.c for function HAL_PWR_EnterSLEEPMode
