### PR TITLE
[LL][USB] Update USB_ClearInterrupts() to not clear all interrupts

### DIFF
--- a/Src/stm32f4xx_ll_usb.c
+++ b/Src/stm32f4xx_ll_usb.c
@@ -1380,7 +1380,7 @@ uint32_t USB_ReadDevInEPInterrupt(USB_OTG_GlobalTypeDef *USBx, uint8_t epnum)
   */
 void  USB_ClearInterrupts(USB_OTG_GlobalTypeDef *USBx, uint32_t interrupt)
 {
-  USBx->GINTSTS |= interrupt;
+  USBx->GINTSTS &= interrupt;
 }
 
 /**


### PR DESCRIPTION
According to RM0090 p1279, RM0368 p708, or RM0383 p707, application write 1 into rc_w1 type bit to clear the interrupt status bits of OTG_FS_GINTSTS register. Inc/stm32f32f4xx_hal_pcd.h:200 macro __HAL_PCD_CLEAR_FLAG also differs with previous implementation.
This may also affect F1(105/7 line), F2, F4, F7, H7, L4(4x5/6 line) series' hal drivers.