### PR TITLE
Fix typo in stm32f4xx_ll_dma.h

### DIFF
--- a/Inc/stm32f4xx_ll_dma.h
+++ b/Inc/stm32f4xx_ll_dma.h
@@ -1171,7 +1171,7 @@ __STATIC_INLINE void LL_DMA_SetCurrentTargetMem(DMA_TypeDef *DMAx, uint32_t Stre
 }
 
 /**
-  * @brief Set Current target (only in double buffer mode) to Memory 1 or Memory 0.
+  * @brief Get Current target (only in double buffer mode).
   * @rmtoll CR          CT           LL_DMA_GetCurrentTargetMem 
   * @param  DMAx DMAx Instance
   * @param  Stream This parameter can be one of the following values:


### PR DESCRIPTION
- [x] I have signed the Contributor License Agreement (CLA)

Same issue occurs in many repositories. Here is a list:

https://github.com/search?q=org%3ASTMicroelectronics+LL_DMA_GetCurrentTargetMem&type=code

But I noticed that [this one](https://github.com/STMicroelectronics/stm32l5xx_hal_driver/blob/master/Inc/stm32l5xx_ll_dma.h#L1104) was correct (except for the missing period). So I copied it.